### PR TITLE
Mitigate locking on infinite body stream

### DIFF
--- a/src/main/scala/com/example/quickstart/Routes.scala
+++ b/src/main/scala/com/example/quickstart/Routes.scala
@@ -1,18 +1,20 @@
 package com.example.quickstart
 
+import scala.concurrent.duration._
 import cats.implicits._
-import cats.effect.Sync
+import cats.effect.Async
+
 import org.http4s.HttpRoutes
 import org.http4s.dsl.Http4sDsl
 
 object Routes {
 
-  def routes[F[_]: Sync](service: Service[F]): HttpRoutes[F] = {
+  def routes[F[_]: Async](service: Service[F]): HttpRoutes[F] = {
     val dsl = new Http4sDsl[F] {}
     import dsl._
     HttpRoutes.of[F] {
       case req @ POST -> Root / vendor / version =>
-        val res = service.cookie(req.bodyText.compile.string.map(Some(_)), s"$vendor/$version", req)
+        val res = service.cookie(req.bodyText.interruptAfter(500.millis).compile.string.map(Some(_)), s"$vendor/$version", req)
         Ok(res)
       case GET -> Root / "health" =>
         Ok("ok")

--- a/src/main/scala/com/example/quickstart/Server.scala
+++ b/src/main/scala/com/example/quickstart/Server.scala
@@ -21,6 +21,7 @@ object Server {
       .withHttpApp(finalApp)
       .withIdleTimeout(610.seconds)
       .withMaxConnections(8126)
+      .withResponseHeaderTimeout(1.seconds)
       .resource
       .useForever
   }


### PR DESCRIPTION
Previously, when a malicious request with a Content-Length set to a value longer than actual length, the application would await until the (infinite) bodyText stream would be completed. Now, we set a sensible timeout on body reading stream and http response. Then, the connection to a load balancer can be maintained but the request is not blocking the connection anymore.